### PR TITLE
Fix: Correct malformed HTML in Education section

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,6 @@
                   Non-equilibrium and spin transport in hybrids of superconductors and magnets
                   </a> (magna cum laude)<br>
                   <em>Quantum Transport Group</em> (supervised by Prof. Dr. Wolfgang Belzig)
-                  </ul>
               </li>
           </ul>
       </section>


### PR DESCRIPTION
Removed a misplaced </ul> tag within the Ph.D. entry for University of Konstanz in the Education section. This resolves an HTML validation error and ensures correct list formatting.